### PR TITLE
Add support for Centos

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+/.python-version

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -110,7 +110,7 @@ iserver_nameservers: 1.1.1.1,1.0.0.1
 
 ### SSH ###
 iserver_ssh_port: 22
-# this picks up the dafault public key from the user
+# this picks up the default public key from the user
 iserver_sshkey: "{{ lookup('file', lookup('env','HOME') + '/.ssh/id_rsa.pub') }}"
 iserver_ssh_banner: none # or /etc/ssh/issue.net
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -89,6 +89,14 @@ iserver_alpine_packages:
   - wget
   - curl
 
+iserver_rpm_packages:
+  - redhat-lsb-core
+  - wget
+  - curl
+
+# Enable EPEL
+iserver_centos_enable_epel: true
+
 ### NETWORKING ###
 iserver_hostname: iserver-kvm
 iserver_domain: unassigned.domain
@@ -181,6 +189,25 @@ iserver_alpine_user_profile: |
   eval "`dircolors`"
   alias ls='ls $LS_OPTIONS'
   export EDITOR=/usr/bin/nano
+
+# CentOS profiles
+iserver_bashrc_root_centos: |
+  export PS1="\[\033[1;31m\][\u@\h:\w]#\[\033[0m\] "
+  export LS_OPTIONS='--color=auto'
+  eval "`dircolors`"
+  alias ls='ls $LS_OPTIONS'
+  alias ll='ls $LS_OPTIONS -l'
+  alias l='ls $LS_OPTIONS -lA'
+  export EDITOR=/usr/bin/vi
+
+iserver_bashrc_user_centos: |
+  export PS1="\[\033[1;34m\][\u@\h:\w]$\[\033[0m\] "
+  export LS_OPTIONS='--color=auto'
+  eval "`dircolors`"
+  alias ls='ls $LS_OPTIONS'
+  alias ll='ls $LS_OPTIONS -l'
+  alias l='ls $LS_OPTIONS -lA'
+  export EDITOR=/usr/bin/vi
 
 # motd
 iserver_motd_welcome: |

--- a/files/auto_grow_partition-centos.sh
+++ b/files/auto_grow_partition-centos.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+# Ansible managed
+# Debian, Ubuntu
+
+growpart -N /dev/sda 3
+if [ $? -eq 0 ]; then
+    echo "* auto-growing and resizing /dev/sda1"
+    growpart /dev/sda 3
+    xfs_growfs /dev/sda3
+fi

--- a/files/autogrowpart-debian-ubuntu.service
+++ b/files/autogrowpart-debian-ubuntu.service
@@ -1,5 +1,5 @@
 # Ansible managed
-# Debian, Ubuntu
+# Debian, Ubuntu, CentOS
 
 [Unit]
 Description=Automatically Grow Partition after resize by Proxmox.

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -24,7 +24,7 @@
   tags:
     - vanilla
 
-# Debian, Ubuntu
+# Debian, Ubuntu, CentOS
 - name: Restart SSH
   service:
     name: ssh
@@ -34,7 +34,7 @@
   tags:
     - vanilla
 
-# Debian, Ubuntu
+# Debian, Ubuntu, CentOS
 - name: Apply Network Configuration
   service:
     name: systemd-logind

--- a/tasks/customize-centos.yml
+++ b/tasks/customize-centos.yml
@@ -1,0 +1,25 @@
+---
+- name: Move the original /etc/motd to back it up (once).
+  command: mv /etc/motd /etc/motd.original
+  args:
+    creates: /etc/motd.original
+
+# This does not update the motd with a new os-release after initial creation.
+- name: Create the file which will show a welcome motd after login.
+  shell: source /etc/os-release && printf "\n $PRETTY_NAME ($VERSION_ID) Server\n\n" > /etc/motd
+  args:
+    creates: /etc/motd
+
+- name: Add a block of bashrc config to the root user (Debian).
+  blockinfile:
+    path: "/root/.bashrc"
+    block: |
+      {{ iserver_bashrc_root_centos }}
+    marker: "# {mark} ANSIBLE MANAGED BLOCK"
+
+- name: Add a block of bashrc config to the default user (Debian).
+  blockinfile:
+    path: "/home/{{ iserver_user }}/.bashrc"
+    block: |
+      {{ iserver_bashrc_user_centos }}
+    marker: "# {mark} ANSIBLE MANAGED BLOCK"

--- a/tasks/growpartition-centos.yml
+++ b/tasks/growpartition-centos.yml
@@ -1,0 +1,32 @@
+# GROW PARTITION
+# CentOS
+
+- name: Ensure we got all packages
+  yum:
+    name: cloud-utils-growpart
+
+
+- name: Copy script to automatically Grow Partition after resize by Proxmox.
+  copy:
+    src: auto_grow_partition-centos.sh
+    dest: /usr/local/bin/auto_grow_partition.sh
+    mode: a+x
+
+
+- name: Copy script to automatically Grow Partition after resize by Proxmox.
+  copy:
+    src: autogrowpart-debian-ubuntu.service
+    dest: /usr/lib/systemd/system/auto_grow_partition.service
+
+    mode: a+x
+
+- name: Setup auto grow part service
+  file:
+    src: /usr/lib/systemd/system/auto_grow_partition.service
+    dest: /etc/systemd/system/multi-user.target.wants/auto_grow_partition.service
+    state: link
+
+- name: Enable auto grow service
+  systemd:
+    name: auto_grow_partition
+    enabled: yes

--- a/tasks/initial-setup-centos.yml
+++ b/tasks/initial-setup-centos.yml
@@ -1,0 +1,187 @@
+---
+
+### Initial Setup ###
+# Centos
+
+# Ideas taken from:
+#    https://github.com/mrlesmithjr/packer-templates
+#    https://github.com/DigitalGlobe/packer-templates
+#    https://github.com/chef/bento
+#
+
+# For this block we use 'su' on first-run, because root cannot ssh into the server.
+- name: KICKSTART - Debian, Ubuntu.
+  block:
+  - name: Ensure that sudo is installed.
+    yum:
+      name: "{{ packages }}"
+      state: present
+    vars:
+      packages:
+      - sudo
+
+  ### SUDOERS ###
+  - name: Ensure group "{{ iserver_user }}" exists
+    group:
+      name: "{{ iserver_user }}"
+      state: present
+
+  - name: Ensure that the default user "{{ iserver_user }}" exists
+    user:
+      name: "{{ iserver_user }}"
+      group: "{{ iserver_user }}"
+      password: '*'
+
+  - name: Add the default user with passwordless sudo to sodoers.d
+    template:
+      src: sudo-default-user.j2
+      dest: /etc/sudoers.d/{{ iserver_user }}
+      mode: 0440
+
+  ## End of block KICKSTART
+  become: true
+  become_method: "{{ iserver_kickstart_become }}"
+  tags:
+    - vanilla
+
+
+- name: Reset SSH connection to allow user changes to affect 'current login user'.
+  meta: reset_connection
+  tags:
+    - vanilla
+
+## Now that the default user can do passwordless sudo, run the rest with sudo.
+- name: MAIN
+  block:
+  ### BASE PACKAGES ###
+  - name: Base Packages.
+    import_tasks: packages-centos.yml
+
+  - name: Create a blank /etc/issue, if it does not exist.
+    file:
+      path: /etc/issue
+      state: touch
+      modification_time: preserve
+      access_time: preserve
+
+  - name: Copy original /etc/issue (once).
+    command: cp /etc/issue /etc/issue.original
+    args:
+      creates: /etc/issue.original
+
+  - name: Set hostname.
+    hostname:
+      name: "{{ iserver_hostname }}"
+    notify:
+      - Apply Network Configuration
+    tags:
+      - vanilla
+      - travis
+
+
+  - name: Networking - Ubuntu.
+    import_tasks: networking-centos.yml
+    tags:
+      - travis
+
+  - name: Copy original hosts file to back it up (once).
+    command: cp /etc/hosts /etc/hosts.original
+    args:
+      creates: /etc/hosts.original
+    tags:
+      - vanilla
+
+  - name: Create new hosts file.
+    template:
+      src: hosts.j2
+      dest: /etc/hosts
+    notify:
+      - Apply Network Configuration
+    tags:
+      - vanilla
+      - travis
+
+  ### SSH ###
+  - name: Ensure that the default user has a SSH authorized key.
+    authorized_key:
+      user: "{{ iserver_user }}"
+      state: present
+      key: "{{ iserver_sshkey }}"
+    tags:
+      - vanilla
+
+  # Needed when running in Travis to validate sshd_config.
+  - name: Ensure that SSH service is started.
+    service:
+      name: sshd
+      state: started
+
+  #'UseDNS no' avoids login delays when the remote client's DNS cannot be resolved
+  - name: Apply SSHD configuration.
+    lineinfile:
+      path: /etc/ssh/sshd_config
+      state: present
+      regexp: '^#?\s*{{ item.key }}\s'
+      line:   '{{ item.key }} {{ item.value }}'
+      validate: '/usr/sbin/sshd -t -f %s'
+    with_items:
+    - key:   "PermitRootLogin"
+      value: "no"
+    - key:   "PasswordAuthentication"
+      value: "no"
+    - key:   "ChallengeResponseAuthentication"
+      value: "no"
+    - key:   "UsePAM"
+      value: "yes"
+    - key:   "UseDNS"
+      value: "no"
+    - key:   "Banner"
+      value: "{{ iserver_ssh_banner }}"
+    - key:   "Port"
+      value: "{{ iserver_ssh_port }}"
+    notify: Restart SSHD
+    tags:
+      - vanilla
+
+  - name: Add a warning banner, shown before SSH login.
+    copy:
+      src: issue.net
+      dest: "{{ iserver_ssh_banner }}"
+    when: iserver_ssh_banner != "none"
+
+  ## CUSTOMIZE ###
+  - name: Timezone.
+    import_tasks: timezone-most-distros.yml
+    tags:
+      - vanilla
+      - travis
+
+  - name: Customize.
+    import_tasks: customize-centos.yml
+
+  ### CLOUD ###
+  - name: Serial Console.
+    import_tasks: serialconsole-centos.yml
+    when: iserver_is_a_vm
+    tags:
+      - vanilla
+      - travis
+
+  # Swap is handled by packer
+
+  # GROW PARTITION
+  - name: Grow Partion Automatically.
+    import_tasks: growpartition-centos.yml
+    when: iserver_is_a_vm
+
+  - name: Lock root account to prevent logins for root from console.
+    user:
+      name: root
+      # or use '*'
+      password: '!'
+    when: iserver_lock_root
+    tags:
+      - vanilla
+
+  ## End of block MAIN
+  become: true

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -22,3 +22,9 @@
   when: ansible_distribution == 'Alpine'
   tags:
     - alpine
+
+- name: Initial Setup - Centos
+  import_tasks: initial-setup-centos.yml
+  when: ansible_distribution == 'CentOS'
+  tags:
+    - centos

--- a/tasks/networking-centos.yml
+++ b/tasks/networking-centos.yml
@@ -1,0 +1,8 @@
+### NETWORKING ###
+# Centos
+- name: Set fixed IP
+  fail:
+    msg: Setting fixed IP is not yet supported
+  when: iserver_static_ip
+  tags:
+    - vanilla

--- a/tasks/packages-centos.yml
+++ b/tasks/packages-centos.yml
@@ -1,0 +1,18 @@
+---
+
+- name: Enable Epel
+  yum:
+    name: epel-release
+    state: present
+  when: iserver_centos_enable_epel
+
+- name: Update Yum packages
+  yum:
+    name: '*'
+    state: latest
+
+
+- name: Ensure that initial packages are installed.
+  yum:
+    name: "{{ iserver_rpm_packages }}"
+    state: present

--- a/tasks/serialconsole-centos.yml
+++ b/tasks/serialconsole-centos.yml
@@ -1,0 +1,14 @@
+# SERIAL CONSOLE
+# Debian, Ubuntu, CENTOS
+
+- name: Enable the serial console by modifying grub.
+  lineinfile:
+    path: /etc/default/grub
+    state: present
+    regexp: '^GRUB_CMDLINE_LINUX='
+    line: 'GRUB_CMDLINE_LINUX="console=ttyS0 console=tty0 net.ifnames=0 biosdevname=0 crashkernel=auto rhgb quiet"'
+  register: update_grub
+
+- name: Update grub.
+  command: grub2-mkconfig -o /boot/grub2/grub.cfg
+  when: update_grub is changed

--- a/templates/hosts.j2
+++ b/templates/hosts.j2
@@ -1,5 +1,5 @@
 # {{ ansible_managed }}
-# Debian, Ubuntu, Alpine, OpenBSD
+# Debian, Ubuntu, Alpine, OpenBSD, CentOS
 
 {{ iserver_ip }} {{ iserver_fqdn }} {{ iserver_hostname }}
 127.0.0.1 localhost.localdomain localhost

--- a/templates/sudo-default-user.j2
+++ b/templates/sudo-default-user.j2
@@ -1,4 +1,4 @@
 # {{ ansible_managed }}
-# Debian, Ubuntu, Alpine
+# Debian, Ubuntu, Alpine, CentOS
 
 {{ iserver_user }}  ALL=(ALL:ALL) NOPASSWD: ALL


### PR DESCRIPTION
Hello,  I really like your set of proxmox templates.  Here is the PR that add support for Centos 7.9

It has almost the same features as the rest of your templates with the following exceptions:

- No support for static IP addresses. ( DHCP only )
- No verse in the profile ( looks like CentOS doesn't provide this package )
- Not so feature rich /etc/motd support.  On CentOS motd is just a static file

 