### PR TITLE
Clean Ubuntu machine ID

### DIFF
--- a/templates/template-cleanup-debian-ubuntu.sh.j2
+++ b/templates/template-cleanup-debian-ubuntu.sh.j2
@@ -34,6 +34,9 @@ echo "==> Zero out the free space to save space in the final image"
 dd if=/dev/zero of=/EMPTY bs=1M  || echo "dd exit code $? is suppressed"
 rm -f /EMPTY
 
+echo "===> Wipe netplan machine-id (DUID) so machines get unique ID generated on boot"
+truncate -s 0 /etc/machine-id
+
 # Make sure we wait until all the data is written to disk, otherwise
 # Packer might quit too early before the large files are deleted
 sync


### PR DESCRIPTION
For some reason all machines clone from your Ubuntu 20.04 template get the same IP address.   This simple patch fixes the issue

Reference:   https://techblog.jeppson.org/2020/05/ubuntu-20-04-cloned-vm-same-dhcp-ip-fix/
